### PR TITLE
Remove engines restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "stellar",
     "interstellar"
   ],
-  "engines": {
-    "node" : ">=6.9 <7"
-  },
   "preferGlobal": true,
   "bin": {
     "interstellar": "./bin/interstellar.js"


### PR DESCRIPTION
This project is still used by the account viewer, and this locks us into an unsupported version of node.